### PR TITLE
Support HTTPS proxy via X-Forwarded-Proto header

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -1,3 +1,8 @@
+map $http_x_forwarded_proto $fastcgi_param_https_variable {
+    default '';
+    https 'on';
+}
+
 server {
     listen 80 default_server;
     listen [::]:80 default_server ipv6only=on;
@@ -26,6 +31,7 @@ server {
         include fastcgi_params;
         fastcgi_pass php-upstream;
         fastcgi_index index.php;
+        fastcgi_param HTTPS $fastcgi_param_https_variable;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param DOCUMENT_ROOT $realpath_root;
         fastcgi_param REALPATHTEST $realpath_root;


### PR DESCRIPTION
## Purpose/Notes
To make Laravel detect https when generate url automatically.

By mapping header `X-Forwarded-Proto` from Apache proxy to Nginx to PHP-FPM env `https=on`.

Example Apache proxy to Nginx in docker:
```apache
<VirtualHost *:443>
    SSLEngine On
    ServerName my.web.test
    ProxyPreserveHost On


    # Set the path to SSL certificate
    # Usage: SSLCertificateFile /path/to/cert.pem
    SSLCertificateFile /etc/apache2/ssl/my.web.test.pem
    SSLCertificateKeyFile /etc/apache2/ssl/my.web.test-key.pem

    # Servers to proxy the connection, or;
    # List of application servers:
    # Usage:
    # ProxyPass / http://[IP Addr.]:[port]/
    # ProxyPassReverse / http://[IP Addr.]:[port]/
    # Example:
    ProxyPass / http://localhost:8008/
    ProxyPassReverse / http://localhost:8008/
    RequestHeader set X-Forwarded-Proto "https"
</VirtualHost>
```